### PR TITLE
Make damage checkboxes mutually exclusive

### DIFF
--- a/Classes/Menu_TabDamage.uc
+++ b/Classes/Menu_TabDamage.uc
@@ -86,11 +86,13 @@ function OnChange(GUIComponent C)
                 MP.DamageIndicator = Centered;
                 class'Misc_Player'.default.DamageIndicator = Centered;
                 moCheckBox(Controls[2]).MyCheckBox.bChecked = true;
+				Controls[3].DisableMe();
             }
             else
             {
                 MP.DamageIndicator = Disabled;
                 class'Misc_Player'.default.DamageIndicator = Disabled;
+				Controls[3].EnableMe();
             }
         }                
 
@@ -101,11 +103,13 @@ function OnChange(GUIComponent C)
                 MP.DamageIndicator = Floating;
                 class'Misc_Player'.default.DamageIndicator = Floating;
                 moCheckBox(Controls[3]).MyCheckBox.bChecked = true;
+				Controls[2].DisableMe();
             }
             else
             {
                 MP.DamageIndicator = Disabled;
                 class'Misc_Player'.default.DamageIndicator = Disabled;
+				Controls[2].EnableMe();
             }
         }                
     }


### PR DESCRIPTION
Disable/enable one checkbox when the other is checked/unchecked.

I think a good option here would be to switch to using a combobox: https://docs.unrealengine.com/en-US/BlueprintAPI/ComboBox/index.html . It's more intuitive for multiple mutually exclusive options and the 3spn menu already has some examples of this. @allenpark , did you look into combo boxes before implementing the checkboxes? Just wondering if you decided against a combobox for any particular reason.